### PR TITLE
Add custom errors

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -31,3 +31,15 @@ Data Classes
 
 .. autoclass:: pyblu.Input
    :members:
+
+Exceptions
+----------
+
+.. autoclass:: pyblu.errors.PlayerError
+   :members:
+
+.. autoclass:: pyblu.errors.PlayerUnreachableError
+   :members:
+
+.. autoclass:: pyblu.errors.PlayerUnexpectedResponseError
+   :members:

--- a/src/pyblu/errors.py
+++ b/src/pyblu/errors.py
@@ -11,8 +11,9 @@ AsyncFuncT = TypeVar("AsyncFuncT", bound=Callable[..., Awaitable[Any]])
 
 
 class PlayerError(Exception):
+    """Base class for exceptions in this package."""
+
     def __init__(self, message: str):
-        """Base class for exceptions in this package."""
         super().__init__(message)
 
 

--- a/src/pyblu/errors.py
+++ b/src/pyblu/errors.py
@@ -1,0 +1,50 @@
+from typing import Callable, TypeVar, Any, cast
+
+from functools import wraps
+
+import aiohttp
+
+__all__ = ["PlayerError", "PlayerUnreachableError", "PlayerUnexpectedResponseError"]
+
+T = TypeVar("T", bound=Callable[..., Any])
+
+
+class PlayerError(Exception):
+    def __init__(self, message: str):
+        """Base class for exceptions in this package."""
+        super().__init__(message)
+
+
+class PlayerUnreachableError(PlayerError):
+    """Exception raised when the player is not reachable.
+
+    This could be due to a timeout or the player being offline.
+    """
+
+
+class PlayerUnexpectedResponseError(PlayerError):
+    """Exception raised when the player returns an unexpected response. This is likely a bug in this library."""
+
+
+def _wrap_in_unxpected_response_error(func: T) -> T:
+    @wraps(func)
+    def wrapped(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except Exception as e:
+            raise PlayerUnexpectedResponseError(f"Unexpected response from player: {e}") from e
+
+    return cast(T, wrapped)
+
+
+def _wrap_in_unreachable_error(func: T) -> T:
+    @wraps(func)
+    def wrapped(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except TimeoutError as e:
+            raise PlayerUnreachableError(f"Timout during request: {e}") from e
+        except aiohttp.ClientConnectionError as e:
+            raise PlayerUnexpectedResponseError(f"Connection error: {e}") from e
+
+    return cast(T, wrapped)

--- a/src/pyblu/parse.py
+++ b/src/pyblu/parse.py
@@ -3,9 +3,14 @@ from urllib.parse import unquote
 from lxml import etree
 
 from pyblu.entities import Input, PairedPlayer, SyncStatus, Status, Volume, PlayQueue, Preset
+from pyblu.errors import _wrap_in_unxpected_response_error
 
 
+@_wrap_in_unxpected_response_error
 def parse_add_slave(response: bytes) -> list[PairedPlayer]:
+    """
+    :raises PlayerUnexpectedResponseError: If the response is not as expected.
+    """
     # pylint: disable=c-extension-no-member
     tree = etree.fromstring(response)
     slave_elements = tree.xpath("//addSlave/slave")
@@ -13,7 +18,11 @@ def parse_add_slave(response: bytes) -> list[PairedPlayer]:
     return [PairedPlayer(ip=x.attrib["id"], port=int(x.attrib["port"])) for x in slave_elements]
 
 
+@_wrap_in_unxpected_response_error
 def parse_sync_status(response: bytes) -> SyncStatus:
+    """
+    :raises PlayerUnexpectedResponseError: If the response is not as expected.
+    """
     # pylint: disable=c-extension-no-member
     tree = etree.fromstring(response)
 
@@ -59,7 +68,11 @@ def parse_sync_status(response: bytes) -> SyncStatus:
     return sync_status
 
 
+@_wrap_in_unxpected_response_error
 def parse_status(response: bytes) -> Status:
+    """
+    :raises PlayerUnexpectedResponseError: If the response is not as expected.
+    """
     # pylint: disable=c-extension-no-member
     tree = etree.fromstring(response)
     status_elements = tree.xpath("//status")
@@ -105,7 +118,11 @@ def parse_status(response: bytes) -> Status:
     return status
 
 
+@_wrap_in_unxpected_response_error
 def parse_volume(response: bytes) -> Volume:
+    """
+    :raises PlayerUnexpectedResponseError: If the response is not as expected.
+    """
     # pylint: disable=c-extension-no-member
     tree = etree.fromstring(response)
     volume_elements = tree.xpath("//volume")
@@ -122,7 +139,11 @@ def parse_volume(response: bytes) -> Volume:
     return volume
 
 
+@_wrap_in_unxpected_response_error
 def parse_play_queue(response: bytes) -> PlayQueue:
+    """
+    :raises PlayerUnexpectedResponseError: If the response is not as expected.
+    """
     # pylint: disable=c-extension-no-member
     tree = etree.fromstring(response)
     playlist_elements = tree.xpath("//playlist")
@@ -140,7 +161,11 @@ def parse_play_queue(response: bytes) -> PlayQueue:
     return play_queue
 
 
+@_wrap_in_unxpected_response_error
 def parse_presets(response: bytes) -> list[Preset]:
+    """
+    :raises PlayerUnexpectedResponseError: If the response is not as expected.
+    """
     # pylint: disable=c-extension-no-member
     tree = etree.fromstring(response)
     preset_elements = tree.xpath("//presets/preset")
@@ -159,7 +184,11 @@ def parse_presets(response: bytes) -> list[Preset]:
     return presets
 
 
+@_wrap_in_unxpected_response_error
 def parse_state(response: bytes) -> str:
+    """
+    :raises PlayerUnexpectedResponseError: If the response is not as expected.
+    """
     # pylint: disable=c-extension-no-member
     tree = etree.fromstring(response)
     state_elements = tree.xpath("//state")
@@ -170,7 +199,11 @@ def parse_state(response: bytes) -> str:
     return state_element.text
 
 
+@_wrap_in_unxpected_response_error
 def parse_sleep(response: bytes) -> int:
+    """
+    :raises PlayerUnexpectedResponseError: If the response is not as expected.
+    """
     # pylint: disable=c-extension-no-member
     tree = etree.fromstring(response)
     sleep_elements = tree.xpath("//sleep")
@@ -181,7 +214,11 @@ def parse_sleep(response: bytes) -> int:
     return int(sleep_element.text) if sleep_element.text else 0
 
 
+@_wrap_in_unxpected_response_error
 def parse_inputs(response: bytes) -> list[Input]:
+    """
+    :raises PlayerUnexpectedResponseError: If the response is not as expected.
+    """
     # pylint: disable=c-extension-no-member
     tree = etree.fromstring(response)
     input_elements = tree.xpath("//radiotime/item")


### PR DESCRIPTION
This wraps timeouts and connection errors in `PlayerUnreachableError` and errors parsing the response in `PlayerUnexpectedResponseError`.