### PR TITLE
Made seconds optional in status

### DIFF
--- a/src/pyblu/entities.py
+++ b/src/pyblu/entities.py
@@ -37,7 +37,7 @@ class Status:
     mute_volume_db: float | None
     """If the player is muted, then this is the unmuted volume level in dB. Absent if the player is not muted."""
 
-    seconds: float
+    seconds: float | None
     """Current playback position in seconds"""
     total_seconds: float | None
     """Total track length in seconds"""

--- a/src/pyblu/parse.py
+++ b/src/pyblu/parse.py
@@ -105,7 +105,7 @@ def parse_status(response: bytes) -> Status:
         mute=status_element.findtext("mute") == "1",
         mute_volume=int(status_element.findtext("muteVolume")) if status_element.findtext("muteVolume") else None,
         mute_volume_db=float(status_element.findtext("muteDb")) if status_element.findtext("muteDb") else None,
-        seconds=float(status_element.findtext("secs")),
+        seconds=float(status_element.findtext("secs")) if status_element.findtext("secs") else None,
         total_seconds=float(status_element.findtext("totlen")) if status_element.findtext("totlen") else None,
         can_seek=status_element.findtext("canSeek") == "1",
         sleep=int(status_element.findtext("sleep")) if status_element.findtext("sleep") else 0,

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -278,7 +278,6 @@ def test_parse_status_optionals():
             
             <mute>1</mute>
             
-            <secs>10</secs>
             <canSeek>1</canSeek>
             
             <sleep>15</sleep>
@@ -299,6 +298,7 @@ def test_parse_status_optionals():
     assert status.mute_volume is None
     assert status.mute_volume_db is None
 
+    assert status.seconds is None
     assert status.total_seconds is None
 
     assert status.group_name is None


### PR DESCRIPTION
`secs` seems to be an optional field. See home-assistant/core#128474