### PR TITLE
Relax dependency versions

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1842,4 +1842,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "7bc41b63d4e04ebef0ee9e5c535c201edbd58452cdf9d5f6f2173024c271f026"
+content-hash = "cafab557ce4bd8f3eac607b36442800ecb4541d7cc6d8c73f09bf6a3bea845ea"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.11"
-aiohttp = "^3.11.11"
-lxml = "^5.0.0"
+aiohttp = ">=3.11.11"
+lxml = ">=5.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pylint = "^3.3.1"


### PR DESCRIPTION
Relax the dependency version ranges to allow the install of lxml 6.0 released last month.
https://github.com/lxml/lxml/blob/lxml-6.0.0/CHANGES.txt

This will help projects which want to move to 3.14 early since wheels for lxml will only be uploaded for newer versions.

The general suggestion in the packaging ecosystem is that libraries should only specify lower bounds, unless strictly necessary, to make it easier for downstream packages and applications.

_It would be awesome if a new could be released after this is merged so I can bump lxml in Home Assistant._