### PR TITLE
Fix: input.text can be None

### DIFF
--- a/src/pyblu/entities.py
+++ b/src/pyblu/entities.py
@@ -157,7 +157,7 @@ class Preset:
 class Input:
     id: str | None
     """Unique id of the input"""
-    text: str
+    text: str | None
     """User friendly name of the input"""
     image: str
     """URL of the input image"""

--- a/src/pyblu/parse.py
+++ b/src/pyblu/parse.py
@@ -226,7 +226,7 @@ def parse_inputs(response: bytes) -> list[Input]:
     inputs = [
         Input(
             id=x.attrib.get("id"),
-            text=x.attrib["text"],
+            text=x.attrib.get("text"),
             image=x.attrib["image"],
             url=unquote(x.attrib["URL"]),
         )

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -638,6 +638,7 @@ async def test_inputs():
           <item typeIndex="bluetooth-1" playerName="Node" text="Bluetooth" inputType="bluetooth" URL="Capture%3Abluez%3Abluetooth" image="/images/BluetoothIcon.png" type="audio"/>
           <item typeIndex="arc-1" playerName="Node" text="HDMI ARC" inputType="arc" id="input2" URL="Capture%3Ahw%3Aimxspdif%2C0%2F1%2F25%2F2%3Fid%3Dinput2" image="/images/capture/ic_tv.png" type="audio"/>
           <item playerName="Node" text="Spotify" id="Spotify" URL="Spotify%3Aplay" image="/Sources/images/SpotifyIcon.png" serviceType="CloudService" type="audio"/>
+          <item id="xdynamic-Source7" type="audio" inputType="analog" URL="Capture%3Ahw%3Asoundchassis%2C0%2F1%2F25%2F2%3Fid%3Dxdynamic-Source7" image="/images/capture/ic_analoginput.png"/>
         </radiotime>
         """,
         )
@@ -650,6 +651,7 @@ async def test_inputs():
             Input(id=None, text="Bluetooth", image="/images/BluetoothIcon.png", url="Capture:bluez:bluetooth"),
             Input(id="input2", text="HDMI ARC", image="/images/capture/ic_tv.png", url="Capture:hw:imxspdif,0/1/25/2?id=input2"),
             Input(id="Spotify", text="Spotify", image="/Sources/images/SpotifyIcon.png", url="Spotify:play"),
+            Input(id="xdynamic-Source7", text=None, image="/images/capture/ic_analoginput.png", url="Capture:hw:soundchassis,0/1/25/2?id=xdynamic-Source7"),
         ]
 
 


### PR DESCRIPTION
There are cases where Input.text can be None: [HomeAssistant Core #150911](https://github.com/home-assistant/core/issues/150991)