### PR TITLE
Fix query parameter used for shuffle

### DIFF
--- a/src/pyblu/player.py
+++ b/src/pyblu/player.py
@@ -403,7 +403,7 @@ class Player:
         used_timeout = timeout if timeout is not None else self._default_timeout
 
         params = {
-            "shuffle": "1" if shuffle else "0",
+            "state": "1" if shuffle else "0",
         }
         async with self._session.get(f"{self.base_url}/Shuffle", params=params, timeout=aiohttp.ClientTimeout(total=used_timeout)) as response:
             response.raise_for_status()

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -463,7 +463,7 @@ async def test_remove_followers():
 async def test_shuffle():
     with aioresponses() as mocked:
         mocked.get(
-            "http://node:11000/Shuffle?shuffle=1",
+            "http://node:11000/Shuffle?state=1",
             status=200,
             body="""
         <playlist id="1" modified="1" length="23" shuffle="1"/>


### PR DESCRIPTION
Shuffle was is using the wrong query parameter `shuffle` instead of `state`.