### PR TITLE
Add return type hints to async methods

### DIFF
--- a/src/pyblu/player.py
+++ b/src/pyblu/player.py
@@ -44,14 +44,14 @@ class Player:
     def default_timeout(self) -> float:
         return self._default_timeout
 
-    async def close(self):
+    async def close(self) -> None:
         if self._session_owned:
             await self._session.close()
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> "Player":
         return self
 
-    async def __aexit__(self, *args):
+    async def __aexit__(self, *args) -> None:
         await self.close()
 
     @_wrap_in_unreachable_error


### PR DESCRIPTION
Thanks for this great library! Music Assistant uses `pyblu`, and since it ships a `py.typed` marker our type checker treats it as fully typed. A few methods are missing return annotations, which makes them count as "untyped" so calling them from our typed code triggers mypy's `no-untyped-call`, forcing us to add `# type: ignore`.

This PR adds some missing annotations to tidy that up.