### PR TITLE
Fix missing timeout propagation in sync_status

### DIFF
--- a/src/pyblu/player.py
+++ b/src/pyblu/player.py
@@ -125,7 +125,7 @@ class Player:
             params["etag"] = etag
             params["timeout"] = str(poll_timeout)
 
-        async with self._session.get(f"{self.base_url}/SyncStatus", params=params) as response:
+        async with self._session.get(f"{self.base_url}/SyncStatus", params=params, timeout=aiohttp.ClientTimeout(total=used_timeout)) as response:
             response.raise_for_status()
             response_data = await response.read()
 


### PR DESCRIPTION
The sync_status method did not propagate the passed timeout(or default timeout) to the underlying aiohttp call. This is fixed here.