### PR TITLE
Fix zone_follower parsing from wrong property

### DIFF
--- a/src/pyblu/parse.py
+++ b/src/pyblu/parse.py
@@ -55,7 +55,7 @@ def parse_sync_status(response: bytes) -> SyncStatus:
         followers=followers,
         zone=sync_status_element.attrib.get("zone"),
         zone_leader=sync_status_element.attrib.get("zoneMaster") == "true",
-        zone_follower=sync_status_element.attrib.get("zoneMaster") == "true",
+        zone_follower=sync_status_element.attrib.get("zoneSlave") == "true",
         brand=sync_status_element.attrib["brand"],
         model=sync_status_element.attrib["model"],
         model_name=sync_status_element.attrib["modelName"],

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -233,7 +233,7 @@ async def test_sync_status():
     db="-17.1" modelName="NODE" model="N130"
     brand="Bluesound" initialized="true" id="1.1.1.1:11000" mac="00:11:22:33:44:55" volume="29"
     name="Node" etag="707" schemaVersion="34" syncStat="707" class="streamer"
-    group="Node +2" zone="Desk" zoneMaster="true" zoneSlave="true">
+    group="Node +2" zone="Desk" zoneMaster="true" zoneSlave="false">
       <pairWithSub/>
       <bluetoothOutput/>
       <master port="11000">192.168.1.100</master>
@@ -259,7 +259,7 @@ async def test_sync_status():
     assert sync_status.followers == [PairedPlayer(ip="192.168.1.153", port=11000), PairedPlayer(ip="192.168.1.234", port=11000)]
     assert sync_status.zone == "Desk"
     assert sync_status.zone_leader
-    assert sync_status.zone_follower
+    assert sync_status.zone_follower is False
     assert sync_status.brand == "Bluesound"
     assert sync_status.model == "N130"
     assert sync_status.model_name == "NODE"


### PR DESCRIPTION
`zone_leader` and `zone_follower` did both parse from `zoneMaster`. `zone_follower` uses the correct `zoneSlave` now.